### PR TITLE
source file, openssl_enc_fmt_plug.c, has been modified ass John is lo…

### DIFF
--- a/src/openssl_enc_fmt_plug.c
+++ b/src/openssl_enc_fmt_plug.c
@@ -319,7 +319,7 @@ static int kpa(unsigned char *key, unsigned char *iv, int inlined)
 			if (memmem(out, cur_salt->datalen, cur_salt->kpt, strlen((char*)cur_salt->kpt)))
 				return 0;
 		} else if (cur_salt->kpa == 2) {
-			int len = check_pkcs_pad(out, cur_salt->datalen, 16);
+			int len = cur_salt->datalen;
 			int nascii = count_ascii(out, len);
 			if ( (nascii * 100) / len >= cur_salt->asciipct )
 				return 0;


### PR DESCRIPTION
…oking for padding. Namley, this is when you need to pad the end of your plaintext to fill up the last block, to ensure that your plaintext length is an integer multiple of the block length, but it is checking it only after decrypting the first 256 bytes of the file.

;