### PR TITLE
Format struct change for non-hashes (we're about to stop abusing the

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -1646,6 +1646,11 @@ void *fmt_default_salt(char *ciphertext)
 	return ciphertext;
 }
 
+fmt_data *fmt_default_data(char *ciphertext)
+{
+	return NULL;
+}
+
 char *fmt_default_source(char *source, void *binary)
 {
 	return source;
@@ -1730,6 +1735,16 @@ void fmt_default_clear_keys(void)
 }
 
 int fmt_default_get_hash(int index)
+{
+	return 0;
+}
+
+int fmt_default_cmp_all_data(fmt_data *data, int count)
+{
+	return 0;
+}
+
+int fmt_default_cmp_one_data(fmt_data *data, int index)
 {
 	return 0;
 }

--- a/src/loader.h
+++ b/src/loader.h
@@ -26,7 +26,9 @@ struct db_password {
 /* Pointer to next password hash with the same salt */
 	struct db_password *next;
 
-/* Hot portion of or full binary ciphertext for fast comparison (aligned) */
+/* Hot portion of or full binary ciphertext for fast comparison (aligned).
+ * Alternatively, for non-hash formats: Non-salt data (that we used to
+ * incorrectly store in a "salt"). */
 	void *binary;
 
 /* After loading is completed: pointer to next password hash with the same salt


### PR DESCRIPTION
salt for storing data blobs). See #3497

* Format flag added: FMT_BLOB (requires a binary_size of 0).
* Format methods added:
    [get_]data(ciphertext)
    cmp_all_data(data, count)
    cmp_one_data(data, index)

Loader struct unchanged. For FMT_BLOB we just re-purpose the binary
pointer.