### PR TITLE
pdf2john: allow symlinked usage by resolving script path

### DIFF
--- a/run/pdf2john.pl
+++ b/run/pdf2john.pl
@@ -24,10 +24,11 @@ require 5.004;
 my $version = '8.99';
 
 # add our 'lib' directory to the include list BEFORE 'use ExifTool'
+use Cwd qw(realpath);
 my $exeDir;
 BEGIN {
     # get exe directory
-    $exeDir = ($0 =~ /(.*)[\\\/]/) ? $1 : '.';
+    $exeDir = (realpath($0) =~ /(.*)[\\\/]/) ? $1 : '.';
     # add lib directory at start of include path
     unshift @INC, "$exeDir/lib";
     # load or disable config file if specified


### PR DESCRIPTION
This resolves the script's real path which is then used to populate
the perl module include path to the appropriate location of the
vendored lib folder.
This allows using pdf2john anywhere as a symlink, f.e. inside $PATH.

Fixes #4089