### PR TITLE
Fiexd mixing condition

### DIFF
--- a/src/stribog_fmt_plug.c
+++ b/src/stribog_fmt_plug.c
@@ -8,7 +8,7 @@
 
 #include "arch.h"
 
-#if !defined(JOHN_NO_SIMD) && __SSE4_1__
+#if !defined(JOHN_NO_SIMD) && defined(__SSE4_1__)
 
 #if FMT_EXTERNS_H
 extern struct fmt_main fmt_stribog_256;


### PR DESCRIPTION
Mixing `defined` and not defined condition at clang over macOS Sierra and High
Sierra, at CPU before SSE4.1 crashed build with logs:

```
==> make -s CC=clang
ar: creating archive aes.a
ar: creating archive secp256k1.a
ar: creating archive ed25519-donna.a
Undefined symbols for architecture x86_64:
  "_fmt_stribog_256", referenced from:
      _john_register_all in john.o
  "_fmt_stribog_512", referenced from:
      _john_register_all in john.o
ld: symbol(s) not found for architecture x86_64
```